### PR TITLE
bugfixes

### DIFF
--- a/custom_components/multizone_thermostat/climate.py
+++ b/custom_components/multizone_thermostat/climate.py
@@ -1318,12 +1318,12 @@ class MultiZoneThermostat(ClimateEntity, RestoreEntity):
                     return
 
             if self._hvac_on.is_hvac_wc_mode:
-                if (
-                    self._sensor_out_entity_id
-                    and self._hvac_on.outdoor_temperature is None
+                if self._sensor_out_entity_id and (
+                    self._hvac_on.outdoor_temperature is None
+                    or self._hvac_on.target_temperature is None
                 ):
                     self._logger.warning(
-                        "Current outdoor temp is None, cannot compare with target"
+                        "Current outdoor temp is %s and setpoint is %s cannot run weather mode"
                     )
                     return
 

--- a/custom_components/multizone_thermostat/climate.py
+++ b/custom_components/multizone_thermostat/climate.py
@@ -634,9 +634,6 @@ class MultiZoneThermostat(ClimateEntity, RestoreEntity):
                 STATE_UNKNOWN,
             ):
                 await self._async_update_current_temp(sensor_state.state)
-                # setup filter after frist temp reading
-                if not self._kf_temp and self.filter_mode > 0:
-                    await self.async_set_filter_mode(self.filter_mode)
 
             if self._sensor_out_entity_id:
                 sensor_state = self.hass.states.get(self._sensor_out_entity_id)
@@ -1199,6 +1196,10 @@ class MultiZoneThermostat(ClimateEntity, RestoreEntity):
             self._logger.debug("Current temperature updated to %s", current_temp)
             # store local in case current hvac mode is off
             self._current_temperature = float(current_temp)
+
+            # setup filter after first temp reading
+            if not self._kf_temp and self.filter_mode > 0:
+                await self.async_set_filter_mode(self.filter_mode)
 
         try:
             if self._kf_temp:

--- a/custom_components/multizone_thermostat/climate.py
+++ b/custom_components/multizone_thermostat/climate.py
@@ -901,7 +901,7 @@ class MultiZoneThermostat(ClimateEntity, RestoreEntity):
         """
 
         self._logger.debug(
-            "update 'pwm alive' for %s per %s seconds",
+            "update 'pwm alive' for %s per %s (hh:mm:ss)",
             self._hvac_mode,
             interval,
         )
@@ -1178,7 +1178,9 @@ class MultiZoneThermostat(ClimateEntity, RestoreEntity):
                 )
                 for mode_def, data in self._hvac_def.items():
                     if data.get_hvac_switch == entity_id:
-                        await self._async_switch_turn_off(hvac_mode=mode_def, force=True)
+                        await self._async_switch_turn_off(
+                            hvac_mode=mode_def, force=True
+                        )
                         break
 
         if new_state is None:

--- a/custom_components/multizone_thermostat/manifest.json
+++ b/custom_components/multizone_thermostat/manifest.json
@@ -6,6 +6,6 @@
   "requirements": ["numpy"],
   "dependencies": [],
   "codeowners": ["@vindaalex"],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
assure init of filter
avoid running wc mode calculation when no setpoint is present
at startup place 'set hvac mode' in HA booted routine as it could require input_number, cover or input_boolean for operation